### PR TITLE
Add translation value 'BTN_SKIP_PAGE' for skip button

### DIFF
--- a/ui-en.json
+++ b/ui-en.json
@@ -7,6 +7,7 @@
     "WELCOME_WIDGET_DELETE_ANY_TIME": "You can delete answers at any time",
     "BTN_NEXT_PAGE": "proceed",
     "BTN_PREV_PAGE": "go back",
+    "BTN_SKIP_PAGE": "skip",
     "LINK_ABOUT": "About distrochooser.de",
     "LANGUAGE": "language",
     "ABOUT_PAGE_TITLE": "About this project",


### PR DESCRIPTION
### Summary
This pull request introduces a new translation value `BTN_SKIP_PAGE` in `ui-en.json` to support the skip button added in the previous pull request.

### Changes:
- Added the translation string `BTN_SKIP_PAGE` in `ui-en.json` for the skip button feature.

### Output:
- The skip button will now display the correct localized text on relevant pages.

This PR completes the work started in `distrochooser/distrochooser#336`, where the skip button was introduced.
